### PR TITLE
fix(redis_lock,redis_lock.asyncio): mypy types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ test = [
     "pytest-asyncio==0.20.3",
     "coverage==7.1.0",
 ]
+dev = [
+    "mypy>=1.16.1",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["redis_lock"]

--- a/redis_lock/asyncio/types.py
+++ b/redis_lock/asyncio/types.py
@@ -1,8 +1,8 @@
 from datetime import timedelta
 from typing import Union
 
-from redis import Redis
+from redis.asyncio import Redis as AsyncRedis
 
-RedisClient = Redis
+RedisClient = AsyncRedis
 LockKey = Union[bytes, str]
 TimeOutType = Union[int, timedelta]

--- a/redis_lock/base.py
+++ b/redis_lock/base.py
@@ -26,7 +26,7 @@ class BaseLock(ABC):
     def __init__(
         self,
         client: RedisClient,
-        name: LockKey = None,
+        name: Optional[LockKey] = None,
         blocking_timeout: int = default_blocking_timeout,
         expire_timeout: Optional[TimeOutType] = None,
     ):
@@ -61,16 +61,11 @@ class BaseLock(ABC):
     def _validate_timeout(blocking_timeout: int):
         if not blocking_timeout:
             raise InvalidArgsError(
-                "A `blocking_timeout` argument should be provided at the "
-                "time of initializing the `Lock` class."
+                "A `blocking_timeout` argument should be provided at the " "time of initializing the `Lock` class."
             )
-        elif (
-            not isinstance(blocking_timeout, (int, float))
-            or blocking_timeout < 0
-        ):
+        elif not isinstance(blocking_timeout, (int, float)) or blocking_timeout < 0:
             raise InvalidArgsError(
-                "A `blocking_timeout` argument should be integer of float and "
-                "cannot be negative."
+                "A `blocking_timeout` argument should be integer of float and " "cannot be negative."
             )
 
 
@@ -88,13 +83,9 @@ class BaseSyncLock(BaseLock):
     @abstractmethod
     def acquire(self, *args, **kwargs):
         """Try to acquire a lock"""
-        raise NotImplementedError(
-            "The `acquire` method should be implemented!"
-        )
+        raise NotImplementedError("The `acquire` method should be implemented!")
 
     @abstractmethod
     def release(self):
         """Release the owned lock"""
-        raise NotImplementedError(
-            "The `release` method should be implemented!"
-        )
+        raise NotImplementedError("The `release` method should be implemented!")

--- a/redis_lock/lock.py
+++ b/redis_lock/lock.py
@@ -1,4 +1,5 @@
 import time
+from typing import Optional
 
 from redis.client import PubSub
 
@@ -10,7 +11,10 @@ class RedisLock(BaseSyncLock):
 
     @property
     def channel_name(self) -> str:
-        return f"rlock-channel:{self.name}"
+        name: Optional[str] = None
+        if type(self.name) is bytes:
+            name = self.name.decode()
+        return f"rlock-channel:{name or self._name!r}"
 
     def _try_acquire(self) -> bool:
         if self._client.set(self.name, self.token, nx=True, ex=self._ex):
@@ -24,16 +28,10 @@ class RedisLock(BaseSyncLock):
     def _wait_for_message(self, pubsub: PubSub, timeout: int) -> bool:
         break_time = time.time() + timeout
         while True:
-            message = pubsub.get_message(
-                ignore_subscribe_messages=True, timeout=timeout
-            )
+            message = pubsub.get_message(ignore_subscribe_messages=True, timeout=timeout)
             if not message and break_time < time.time():
                 return False
-            elif (
-                message
-                and message["type"] == "message"
-                and message["data"] == self.unlock_message
-            ):
+            elif message and message["type"] == "message" and message["data"] == self.unlock_message:
                 return True
 
     def acquire(self) -> bool:

--- a/redis_lock/spin_lock.py
+++ b/redis_lock/spin_lock.py
@@ -1,4 +1,5 @@
 import time
+from typing import Optional
 
 from redis_lock.base import BaseSyncLock
 from redis_lock.exceptions import LockNotOwnedError
@@ -28,7 +29,7 @@ class RedisSpinLock(BaseSyncLock):
         Returns:
            bool: `True` if the lock was acquired, `False` otherwise.
         """
-        timeout = self._blocking_timeout
+        timeout = float(self._blocking_timeout)
 
         while True:
             current = time.time()
@@ -37,7 +38,7 @@ class RedisSpinLock(BaseSyncLock):
             elif not blocking:
                 return False
             time.sleep(sleep_time)
-            timeout -= (time.time() - current)
+            timeout -= time.time() - current
             if timeout < 0:
                 return False
 


### PR DESCRIPTION
Fix all occurrences of typing issues produced by mypy. This includes adding typing to redis_lock.asyncio.

Includes a potential breaking change, where the expiration time for the lock could be set to a float. However, Redis does not support floats which was potentially problematic.