### PR TITLE
Add Python 3.14 and drop 3.9 support

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -13,9 +13,9 @@ jobs:
     name: TEST ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
+      max-parallel: 5
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     services:
       redis:
         image: redis
@@ -54,7 +54,7 @@ jobs:
     - name: SET UP PYTHON
       uses: actions/setup-python@v4
       with:
-        python-version: "3.13"
+        python-version: "3.14"
     - name: INSTALL DEPENDENCIES
       run: |
         python -m pip install --upgrade build

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $> pip install redis-lock-py
 ```
 
 ### Dependencies
-- Python >= 3.9
+- Python >= 3.10
 - redis-py >= 5.2.0
 
 ## 3. Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,17 +10,17 @@ authors = [
 ]
 description = "Redis distributed lock implementation for Python based on Pub/Sub messaging"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "MIT"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies=[
     "redis>=5.2.0"


### PR DESCRIPTION
## Summary
Add Python 3.14 and drop 3.9 support

## Changes
- Drop Python 3.9 support.
- Add support for Python 3.14.

## Related Issues
<!-- Link any related issues (e.g., Closes #12, Fixes #34) -->
- 

## Checklist

- [x] Verified the feature works as expected locally
- [x] All tests (existing and new) pass
- [x] Related issues are properly linked
