### PR TITLE
fix: Upgrade dependencies to resolve deprecated code execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $> pip install redis-lock-py
 
 ### Dependencies
 - Python >= 3.10
-- redis-py >= 5.2.0
+- redis-py >= 7.0.1
 
 ## 3. Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies=[
-    "redis>=5.2.0"
+    "redis>=7.0.1"
 ]
 
 [project.urls]
@@ -31,9 +31,9 @@ Homepage = "https://github.com/miintto/redis-lock-py"
 
 [project.optional-dependencies]
 test = [
-    "pytest==7.2.1",
-    "pytest-asyncio==0.20.3",
-    "coverage==7.1.0",
+    "coverage>=7.11.3",
+    "pytest>=9.0.1",
+    "pytest-asyncio>=1.3.0",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
## Summary
Upgrade dependencies

## Changes
- Upgrade version of redis-py, pytest, coverage
  - redis: `5.2.0` to **`7.0.1`**
  - coverage: `7.1.0` to **`7.11.3`**
  - pytest: `7.2.1` to **`9.0.1`**
  - pytest-asyncio: 0.20.3 to **`1.3.0`**
- This resolves incorrect execution of deprecated legacy code in pytest caused by outdated test utilities.

## Checklist

- [x] Verified the feature works as expected locally
- [x] All tests (existing and new) pass
- [x] Related issues are properly linked
