### PR TITLE
Add extend method to extend lock TTL

### DIFF
--- a/redis_lock/asyncio/async_lock.py
+++ b/redis_lock/asyncio/async_lock.py
@@ -3,7 +3,7 @@ import time
 from redis.asyncio.client import PubSub
 
 from redis_lock.asyncio.base import BaseAsyncLock
-from redis_lock.exceptions import LockNotOwnedError
+from redis_lock.exceptions import ExtendFailedError, LockNotOwnedError
 
 
 class RedisLock(BaseAsyncLock):
@@ -86,4 +86,22 @@ class RedisLock(BaseAsyncLock):
             args=(self.token, self.unlock_message),
         ):
             raise LockNotOwnedError("Unable to release non-owned lock.")
+        return True
+
+    async def extend(self, additional_time: int) -> bool:
+        """Extend the owned lock
+
+        Args:
+            additional_time: The additional time in seconds to extend the lock.
+
+        Returns:
+            bool: `True` if the lock was successfully extended,
+                `False` otherwise.
+        """
+        extend_script = self._client.register_script(self.LUA_EXTEND)
+        if not await extend_script(
+            keys=(self.name,),
+            args=(self.token, additional_time),
+        ):
+            raise ExtendFailedError("Unable to extend non-owned lock.")
         return True

--- a/redis_lock/asyncio/base.py
+++ b/redis_lock/asyncio/base.py
@@ -30,3 +30,10 @@ class BaseAsyncLock(BaseLock[Redis]):
         raise NotImplementedError(
             "The `release` method should be implemented!"
         )
+
+    @abstractmethod
+    async def extend(self, additional_time: int) -> bool:
+        """Extend the owned lock"""
+        raise NotImplementedError(
+            "The `extend` method should be implemented!"
+        )

--- a/redis_lock/base.py
+++ b/redis_lock/base.py
@@ -102,3 +102,10 @@ class BaseSyncLock(BaseLock[Redis]):
         raise NotImplementedError(
             "The `release` method should be implemented!"
         )
+
+    @abstractmethod
+    def extend(self, additional_time: int) -> bool:
+        """Extend the owned lock"""
+        raise NotImplementedError(
+            "The `extend` method should be implemented!"
+        )

--- a/redis_lock/base.py
+++ b/redis_lock/base.py
@@ -24,6 +24,20 @@ class BaseLock(Generic[RedisClient], ABC):
         return 1
     """
 
+    # keys: (Lock.name,)
+    # args: (Lock.token, additional_time)
+    LUA_EXTEND = """
+        if redis.call("GET", KEYS[1]) ~= ARGV[1] then
+            return 0
+        end
+        local expiration = redis.call("TTL", KEYS[1])
+        if expiration < 0 then
+            return 0
+        end
+        redis.call("EXPIRE", KEYS[1], expiration + ARGV[2])
+        return 1
+    """
+
     def __init__(
         self,
         client: RedisClient,

--- a/redis_lock/exceptions.py
+++ b/redis_lock/exceptions.py
@@ -12,3 +12,7 @@ class LockNotOwnedError(RedisLockError):
 
 class AcquireFailedError(RedisLockError):
     pass
+
+
+class ExtendFailedError(RedisLockError):
+    pass

--- a/redis_lock/lock.py
+++ b/redis_lock/lock.py
@@ -3,7 +3,7 @@ import time
 from redis.client import PubSub
 
 from redis_lock.base import BaseSyncLock
-from redis_lock.exceptions import LockNotOwnedError
+from redis_lock.exceptions import ExtendFailedError, LockNotOwnedError
 
 
 class RedisLock(BaseSyncLock):
@@ -86,4 +86,22 @@ class RedisLock(BaseSyncLock):
             args=(self.token, self.unlock_message),
         ):
             raise LockNotOwnedError("Unable to release non-owned lock.")
+        return True
+
+    def extend(self, additional_time: int) -> bool:
+        """Extend the owned lock
+
+        Args:
+            additional_time: The additional time in seconds to extend the lock.
+
+        Returns:
+            bool: `True` if the lock was successfully extended,
+                `False` otherwise.
+        """
+        extend_script = self._client.register_script(self.LUA_EXTEND)
+        if not extend_script(
+            keys=(self.name,),
+            args=(self.token, additional_time),
+        ):
+            raise ExtendFailedError("Unable to extend non-owned lock.")
         return True

--- a/redis_lock/spin_lock.py
+++ b/redis_lock/spin_lock.py
@@ -1,7 +1,7 @@
 import time
 
 from redis_lock.base import BaseSyncLock
-from redis_lock.exceptions import LockNotOwnedError
+from redis_lock.exceptions import ExtendFailedError, LockNotOwnedError
 
 
 class RedisSpinLock(BaseSyncLock):
@@ -51,4 +51,22 @@ class RedisSpinLock(BaseSyncLock):
         release_script = self._client.register_script(self.LUA_RELEASE)
         if not release_script(keys=(self.name,), args=(self.token,)):
             raise LockNotOwnedError("Unable to release non-owned lock.")
+        return True
+
+    def extend(self, additional_time: int) -> bool:
+        """Extend the owned lock
+
+        Args:
+            additional_time: The additional time in seconds to extend the lock.
+
+        Returns:
+            bool: `True` if the lock was successfully extended,
+                `False` otherwise.
+        """
+        extend_script = self._client.register_script(self.LUA_EXTEND)
+        if not extend_script(
+            keys=(self.name,),
+            args=(self.token, additional_time),
+        ):
+            raise ExtendFailedError("Unable to extend non-owned lock.")
         return True

--- a/tests/test_async_lock.py
+++ b/tests/test_async_lock.py
@@ -7,6 +7,7 @@ from redis.asyncio import Redis
 from redis_lock.asyncio import RedisLock
 from redis_lock.exceptions import (
     AcquireFailedError,
+    ExtendFailedError,
     InvalidArgsError,
     LockNotOwnedError,
 )
@@ -95,3 +96,42 @@ class TestAsyncLock:
             asyncio.create_task(release_lock()),
         )
         assert .5 < time.time() - current < 1
+
+    @pytest.mark.asyncio
+    async def test_extend(self, aredis: Redis):
+        name = "async_test_extend"
+        lock = RedisLock(aredis, name, expire_timeout=10)
+        assert await lock.acquire()
+        ttl_before = await aredis.ttl(name)
+        assert await lock.extend(20)
+        ttl_after = await aredis.ttl(name)
+        assert ttl_after > ttl_before
+        await lock.release()
+
+    @pytest.mark.asyncio
+    async def test_extend_non_owned_lock(self, aredis: Redis):
+        name = "async_test_extend_non_owned_lock"
+        lock = RedisLock(aredis, name, expire_timeout=10)
+        assert await lock.acquire()
+        await aredis.set(name, lock.token + b"foo")
+        with pytest.raises(ExtendFailedError):
+            await lock.extend(20)
+        await aredis.delete(name)
+
+    @pytest.mark.asyncio
+    async def test_extend_without_expire(self, aredis: Redis):
+        name = "async_test_extend_without_expire"
+        lock = RedisLock(aredis, name)
+        assert await lock.acquire()
+        with pytest.raises(ExtendFailedError):
+            await lock.extend(20)
+        await lock.release()
+
+    @pytest.mark.asyncio
+    async def test_extend_after_release(self, aredis: Redis):
+        name = "async_test_extend_after_release"
+        lock = RedisLock(aredis, name, expire_timeout=10)
+        assert await lock.acquire()
+        await lock.release()
+        with pytest.raises(ExtendFailedError):
+            await lock.extend(20)

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -7,6 +7,7 @@ from redis import Redis
 from redis_lock import RedisLock, RedisSpinLock
 from redis_lock.exceptions import (
     AcquireFailedError,
+    ExtendFailedError,
     InvalidArgsError,
     LockNotOwnedError,
 )
@@ -86,6 +87,41 @@ class TestLock:
         t.join()
         assert .5 < time.time() - current < 1
 
+    def test_extend(self, redis: Redis):
+        name = "test_extend"
+        lock = RedisLock(redis, name, expire_timeout=10)
+        assert lock.acquire()
+        ttl_before = redis.ttl(name)
+        assert lock.extend(20)
+        ttl_after = redis.ttl(name)
+        assert ttl_after > ttl_before
+        lock.release()
+
+    def test_extend_non_owned_lock(self, redis: Redis):
+        name = "test_extend_non_owned_lock"
+        lock = RedisLock(redis, name, expire_timeout=10)
+        assert lock.acquire()
+        redis.set(name, lock.token + b"foo")
+        with pytest.raises(ExtendFailedError):
+            lock.extend(20)
+        redis.delete(name)
+
+    def test_extend_without_expire(self, redis: Redis):
+        name = "test_extend_without_expire"
+        lock = RedisLock(redis, name)
+        assert lock.acquire()
+        with pytest.raises(ExtendFailedError):
+            lock.extend(20)
+        lock.release()
+
+    def test_extend_after_release(self, redis: Redis):
+        name = "test_extend_after_release"
+        lock = RedisLock(redis, name, expire_timeout=10)
+        assert lock.acquire()
+        lock.release()
+        with pytest.raises(ExtendFailedError):
+            lock.extend(20)
+
     def test_spin_lock(self, redis: Redis):
         name = "test_spin_lock"
         with RedisSpinLock(redis, name):
@@ -106,4 +142,23 @@ class TestLock:
         redis.set(name, lock.token + b"foo")
         with pytest.raises(LockNotOwnedError):
             lock.release()
+        redis.delete(name)
+
+    def test_spin_lock_extend(self, redis: Redis):
+        name = "test_spin_lock_extend"
+        lock = RedisSpinLock(redis, name, expire_timeout=10)
+        assert lock.acquire()
+        ttl_before = redis.ttl(name)
+        assert lock.extend(20)
+        ttl_after = redis.ttl(name)
+        assert ttl_after > ttl_before
+        lock.release()
+
+    def test_spin_lock_extend_non_owned(self, redis: Redis):
+        name = "test_spin_lock_extend_non_owned"
+        lock = RedisSpinLock(redis, name, expire_timeout=10)
+        assert lock.acquire()
+        redis.set(name, lock.token + b"foo")
+        with pytest.raises(ExtendFailedError):
+            lock.extend(20)
         redis.delete(name)


### PR DESCRIPTION
## Summary
Add `extend` method to allow extending the TTL of an acquired lock by a specified duration. The operation is performed atomically via a Lua script that verifies token ownership and accumulates the additional time onto the current TTL.

## Changes
<!-- List the main changes made in this PR -->
- Add `LUA_EXTEND` Lua script to `BaseLock` (token verification → TTL lookup → TTL accumulation)
- Implement `extend(additional_time)` in `RedisLock`, `RedisSpinLock`, and async `RedisLock`
- Add `ExtendFailedError` exception class
- Add extend-related test cases (sync/async)
  - Successful extend with TTL increase verification
  - Extend on a non-owned lock raises error
  - Extend on a lock without expire raises error
  - Extend after release raises error

## Related Issues
<!-- Link any related issues (e.g., Closes #12, Fixes #34) -->
- #10 

## Checklist

- [x] Verified the feature works as expected locally
- [x] All tests (existing and new) pass
- [x] Related issues are properly linked
